### PR TITLE
Fix permission checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-update-static-content",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "An strapi plugin to rebuild and deploy your SSG website via Github Actions.",
   "strapi": {
     "name": "update-static-content",

--- a/server/policies/index.js
+++ b/server/policies/index.js
@@ -15,13 +15,13 @@ module.exports = {
       hasPermission = configRoles.some((configRole) => {
         return configRole == adminRole.code;
       });
+      
+      if (hasPermission){
+        return hasPermission;
+      }
     }
 
-    if (!hasPermission) {
-      throw new PolicyError('ACCESS_DENIED', { type: 'ROLES_AND_PERMISSIONS' });
-    }
-
-    return hasPermission;
+    throw new PolicyError('ACCESS_DENIED', { type: 'ROLES_AND_PERMISSIONS' });
   },
   validatePluginConfig: (ø1, ø2, { strapi }) => {
     const pluginConfig = buildPluginConfig(strapi);


### PR DESCRIPTION
The previous implementation has issues with role orders. 
Consider the following example:
The config has the following permissions set:
```
['strapi-super-admin', 'strapi-editor']
```

And the user has the permissions:
```
['strapi-editor', 'strapi-author']
```

In the previous implementation, on the first iteration of `adminRoles`, it will set `hasPermission` to `true` and set it back to `false` on the second iteration. This PR fixes that so that it immediately returns on the first time it detects `hasPermission` is set to true which entirely skips all the remaining iterations. If hasPermission never becomes true, it just throws an error